### PR TITLE
Fixed typo in link to license.

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -1,7 +1,7 @@
 /*global ko, jQuery*/
 
 // Github repository: https://github.com/One-com/knockout-dragdrop
-// License: standard 3-clause BSD license https://raw.github.com/One-com/knockout-dragdrop/master/LICENCE
+// License: standard 3-clause BSD license https://raw.github.com/One-com/knockout-dragdrop/master/LICENSE
 
 (function (factory) {
     if (typeof define === "function" && define.amd) {


### PR DESCRIPTION
URL had "LICENCE" instead of "LICENSE".
