### PR TITLE
startDrag call order fixed

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -363,11 +363,11 @@
                     $(document).on('selectstart.drag', false);
 
                     function startDragging(startEvent) {
+                        $(element).off('mouseup.startdrag click.startdrag mouseleave.startdrag mousemove.startdrag');
+                        
                         if (draggable.startDrag(downEvent) === false) {
                             return false;
                         }
-                        
-                        $(element).off('mouseup.startdrag click.startdrag mouseleave.startdrag mousemove.startdrag');
 
                         var dragElement = null;
                         if (!options.element) {


### PR DESCRIPTION
If startDrag returns false, no drag should occur. startDrag should be called first to check if dragging should occur and only then create a dragElement.
