### PR TITLE
CommonJS and ES2015 Module Style Support

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -6,9 +6,9 @@
     if (typeof define === "function" && define.amd) {
         // AMD anonymous module with hard-coded dependency on "knockout"
         define(["knockout"], factory);
-    } else if(typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+    } else if (typeof module === 'object' && module.exports) {
         // CommonJS or Node: hard-coded dependency on "knockout"
-        factory(require("knockout"), exports);
+        module.exports = factory(require("knockout"));
     } else {
         // <script> tag: use the global `ko`
         factory(ko);

--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -6,6 +6,9 @@
     if (typeof define === "function" && define.amd) {
         // AMD anonymous module with hard-coded dependency on "knockout"
         define(["knockout"], factory);
+    } else if(typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+        // CommonJS or Node: hard-coded dependency on "knockout"
+        factory(require("knockout"), exports);
     } else {
         // <script> tag: use the global `ko`
         factory(ko);


### PR DESCRIPTION
Added support for the CommonJS module style. This also supports the new ES2015 import syntax when using Babel, since Babel compiles import statements to require statements.

Using ES2015 and Babel,` knockout-dragdrop` can be imported like this:
```
import $ from 'jquery';
import ko from 'knockout';
import 'knockout-dragdrop';
```

This is a bit of a drive by PR, so let me know if I need to do anything else or change anything. And thanks!