### PR TITLE
Don't cancel selectstart event on textarea

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -501,7 +501,7 @@
                 }
 
                 element.addEventListener('selectstart', function (event) {
-                    if (!event.target.tagName || event.target.tagName.toLowerCase() !== 'input') {
+                    if (!event.target.tagName || event.target.tagName.toLowerCase() !== 'input' && event.target.tagName.toLowerCase() !== 'textarea') {
                         event.preventDefault();
                         event.stopPropagation();
                         return false;


### PR DESCRIPTION
In our web-app in chrome and IE11 Ctrl+A didn't work on a textarea what was a drop-zone.