### PR TITLE
CSS-class to identify zones that are possible to drop on on drag start.

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -93,6 +93,7 @@
         this.dragEnter = args.dragEnter;
         this.dragOver = args.dragOver;
         this.dragLeave = args.dragLeave;
+		this.possibleOnDrag = args.possibleOnDrag;
         this.active = false;
         this.inside = false;
         this.dirty = false;
@@ -173,8 +174,13 @@
     }
     DropZone.prototype = Zone.prototype;
 
+    DropZone.prototype.removePossibleDrag = function() {
+        toggleClass(this.element, 'drag-possible', false);
+    }
+
     DropZone.prototype.updateStyling = function () {
         if (this.dirty) {
+			toggleClass(this.element, 'drag-possible', this.possibleOnDrag);
             toggleClass(this.element, 'drag-over', this.active);
             toggleClass(this.element, 'drop-rejected', this.inside && !this.active);
         }
@@ -270,6 +276,7 @@
 
         forEach(dropZones[name], function (zone) {
             zone.updateStyling();
+			zone.removePossibleDrag();
         });
 
         if (winningDropZone && winningDropZone.drop) {
@@ -394,6 +401,7 @@
                     element: element,
                     data: data,
                     drop: options.drop,
+					possibleOnDrag: options.possibleOnDrag,
                     dragEnter: options.dragEnter,
                     dragOver: options.dragOver,
                     dragLeave: options.dragLeave


### PR DESCRIPTION
CSS-class to identify zones that are possible to drop on on drag start.
I needed to identify where I am able to drop objects before they hover. This solves that problem.