### PR TITLE
Fix memory leak when using custom templates

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -197,7 +197,7 @@
     };
 
     DragElement.prototype.remove = function () {
-        this.element.parentNode.removeChild(this.element);
+        ko.removeNode(this.element);
     };
 
     function Draggable(args) {


### PR DESCRIPTION
Use ko.removeNode to make sure to clean up the knockout context