### PR TITLE
Make library more dynamic

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -744,7 +744,6 @@
                     element.removeEventListener('selectstart', selectStart, true);
                     element.removeEventListener('mousedown', beginEvent);
                     element.removeEventListener('touchstart', beginEvent);
-                    element.removeEventListener('touchend', beginEvent);
                 });
             }
         },

--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -16,6 +16,7 @@
 })(function (ko) {
     var dropZones = {};
     var eventZones = {};
+    var createdDragEvents = [];
 
     var forEach = ko.utils.arrayForEach;
     var first = ko.utils.arrayFirst;
@@ -128,17 +129,17 @@
         return true;
     };
 
-    Zone.prototype.update = function (event, data) {
+    Zone.prototype.update = function (event, data, enter_list, leave_list, drag_over_list) {
         if (this.isInside(getEventCoord(event, 'pageX'), getEventCoord(event, 'pageY'))) {
             if (!this.inside) {
-                this.enter(event, data);
+                enter_list.push(this.enter.bind(this, event, data));
             }
 
             if (this.dragOver) {
-                this.dragOver(event, data, this.data);
+                drag_over_list.push(this.dragOver.bind(this, event, data, this.data));
             }
         } else {
-            this.leave(event);
+            leave_list.push(this.leave.bind(this, event));
         }
     };
 
@@ -224,10 +225,23 @@
             zone.refreshDomInfo();
         });
 
+        let enter_list = [], leave_list = [], drag_over_list = [];
         forEach(zones, function (zone) {
             event.target = zone.element;
-            zone.update(event, that.data);
+            zone.update(event, that.data, enter_list, leave_list, drag_over_list);
         });
+
+        for (let callback of leave_list) {
+            callback();
+        }
+
+        for (let callback of enter_list) {
+            callback();
+        }
+
+        for (let callback of drag_over_list) {
+            callback();
+        }
 
         forEach(dropZones[name], function (zone) {
             zone.updateStyling();
@@ -437,12 +451,16 @@
                     eventZones[zoneName].push(zone);
                 });
 
-                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                let dispose = function () {
                     zone.leave();
                     accepts.forEach(function (zoneName) {
                         eventZones[zoneName].splice(eventZones[zoneName].indexOf(zone), 1);
                     });
-                });
+                };
+
+                createdDragEvents.push({element: element, dispose: dispose});
+
+                ko.utils.domNodeDisposal.addDisposeCallback(element, dispose);
             }
         },
 
@@ -518,6 +536,7 @@
                         return true;
                     }
 
+                    //TODO: Fix the dragging issue in firefox - PWHI-4263 - Micro Drag and Drop doesn't work in Firefox
                     document.addEventListener('selectstart', onSelectStartDrag, true);
 
                     function startDragging(startEvent) {
@@ -726,7 +745,7 @@
         },
 
         scrollableOnDragOver: {
-            init: function (element, valueAccessor, allBindingAccessor) {
+            update: function (element, valueAccessor, allBindingAccessor) {
                 var options = ko.utils.unwrapObservable(valueAccessor());
                 if (typeof options === 'string' || Array.isArray(options)) {
                     options = { accepts: options };
@@ -755,6 +774,18 @@
                     clearInterval(scrollInterval);
                 }
 
+                function removeCreatedDragEvents() {
+                    for (let item of createdDragEvents) {
+                        if (item && item.element === element) {
+                            item.dispose();
+                            createdDragEvents.splice(createdDragEvents.indexOf(item), 1);
+                            break;
+                        }
+                    }
+                }
+
+                removeCreatedDragEvents();
+
                 ko.bindingHandlers.dragEvents.init(element, function () {
                     return {
                         accepts: accepts,
@@ -762,6 +793,10 @@
                         dragOver: dragOver,
                         dragLeave: dragLeave
                     };
+                });
+
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                    removeCreatedDragEvents();
                 });
             }
         }

--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -536,7 +536,6 @@
                         return true;
                     }
 
-                    //TODO: Fix the dragging issue in firefox - PWHI-4263 - Micro Drag and Drop doesn't work in Firefox
                     document.addEventListener('selectstart', onSelectStartDrag, true);
 
                     function startDragging(startEvent) {

--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -521,14 +521,16 @@
                     event.stopPropagation();
                 }
 
-                element.addEventListener('selectstart', function (event) {
+                function selectStart(event) {
                     if (!event.target.tagName || event.target.tagName.toLowerCase() !== 'input' && event.target.tagName.toLowerCase() !== 'textarea') {
                         event.preventDefault();
                         event.stopPropagation();
                         return false;
                     }
                     return true;
-                }, true);
+                }
+
+                element.addEventListener('selectstart', selectStart, true);
 
                 toggleClass(element, 'draggable', true);
                 function beginEvent(downEvent) {
@@ -739,6 +741,10 @@
 
                 ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
                     document.removeEventListener('selectstart', onSelectStartDrag, true);
+                    element.removeEventListener('selectstart', selectStart, true);
+                    element.removeEventListener('mousedown', beginEvent);
+                    element.removeEventListener('touchstart', beginEvent);
+                    element.removeEventListener('touchend', beginEvent);
                 });
             }
         },


### PR DESCRIPTION
- Make scrollableOnDragOver binding use update instead of init so bound values can be computeds or observables.
- Make the library call leave and enter in the correct order and then remove dragOver